### PR TITLE
Removes iOS 11 Specific Constants

### DIFF
--- a/ios/src/ImageCropPicker.m
+++ b/ios/src/ImageCropPicker.m
@@ -284,11 +284,11 @@ RCT_EXPORT_METHOD(openPicker:(NSDictionary *)options
                                          @"SyncedFaces" : @(PHAssetCollectionSubtypeAlbumSyncedFaces),
                                          @"SyncedAlbum" : @(PHAssetCollectionSubtypeAlbumSyncedAlbum),
                                          @"Imported" : @(PHAssetCollectionSubtypeAlbumImported),
-                                         
+
                                          //cloud albums
                                          @"PhotoStream" : @(PHAssetCollectionSubtypeAlbumMyPhotoStream),
                                          @"CloudShared" : @(PHAssetCollectionSubtypeAlbumCloudShared),
-                                         
+
                                          //smart albums
                                          @"Generic" : @(PHAssetCollectionSubtypeSmartAlbumGeneric),
                                          @"Panoramas" : @(PHAssetCollectionSubtypeSmartAlbumPanoramas),
@@ -304,8 +304,6 @@ RCT_EXPORT_METHOD(openPicker:(NSDictionary *)options
                                          @"Screenshots" : @(PHAssetCollectionSubtypeSmartAlbumScreenshots),
                                          @"DepthEffect" : @(PHAssetCollectionSubtypeSmartAlbumDepthEffect),
                                          @"LivePhotos" : @(PHAssetCollectionSubtypeSmartAlbumLivePhotos),
-                                         @"Animated" : @(PHAssetCollectionSubtypeSmartAlbumAnimated),
-                                         @"LongExposure" : @(PHAssetCollectionSubtypeSmartAlbumLongExposures),
                                          };
                 NSMutableArray *albumsToShow = [NSMutableArray arrayWithCapacity:smartAlbums.count];
                 for (NSString* smartAlbum in smartAlbums) {


### PR DESCRIPTION
We need to be able to build using Xcode 8.3.3 but these two constants are only available in iOS 11 (XCode 9). Since we don't really care about these albums we can just remove them for now.